### PR TITLE
feat: vercel 배포 이슈 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,20 @@
 import type { NextConfig } from "next";
 
+/**
+ * Mixed Content: The page at 'https://...' was loaded over HTTPS, but requested an insecure resource 'http://...'. This request has been blocked; the content must be served over HTTPS.
+ * 암호화된 HTTPS 페이지에 암호화가 안 된 HTTP를 사용해 요청했을때 발생해서 임시 추가
+ *  **/
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
``` Mixed Content: The page at 'https://...' was loaded over HTTPS, but requested an insecure resource 'http://...'. This request has been blocked; the content must be served over HTTPS ```

 * 암호화된 HTTPS 페이지에 암호화가 안 된 HTTP를 사용해 요청했을때 발생해서 임시 추가